### PR TITLE
Make npm scripts work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "uix-starter",
   "scripts": {
-    "dev": "shadow-cljs -A:dev watch app & npm run styles-dev",
-    "release": "shadow-cljs -A:dev release app && npm run styles-release",
-    "styles-dev": "onchange -o '> public/main.css && lightningcss --bundle public/main.css -o public/main.css' -i src/**/*.css -- cat src/**/*.css",
-    "styles-release": "cat src/**/*.css > public/main.css && lightningcss --minify --bundle public/main.css -o public/main.css"
+    "dev": "shadow-cljs -A :dev watch app & npm run styles-dev",
+    "release": "shadow-cljs -A :dev release app && npm run styles-release",
+    "styles-dev": "onchange -o '> public/main.css && lightningcss --bundle public/main.css -o public/main.css' -i $(find src -name *.css) -- cat $(find src -name *.css)",
+    "styles-release": "cat $(find src -name *.css) > public/main.css && lightningcss --minify --bundle public/main.css -o public/main.css"
   },
   "devDependencies": {
     "lightningcss-cli": "^1.30.1",


### PR DESCRIPTION
* Add a space between -A and :dev in shadow-cljs call
* Don't rely on shell globstar for collecting css files

Closes #15.